### PR TITLE
Aaron/add help behavior

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -26,17 +26,17 @@ keywords = ["basic",
             "repository"] #change these to your project keywords
 
 dependencies = [
-"numpy",
-"pyqt6",
-"pyqtgraph",
-"scipy",
-"rich",
-"pandas",
-"matplotlib",
-"toml",
-] #add additional dependencies here - try to pin versions as minimally as possible
+"numpy==1.26.2",
+"pyside6==6.6.*",
+"pyqtgraph==0.13.3",
+"scipy==1.11.4",
+"rich==13.7.0",
+"pandas==2.1.4",
+"matplotlib==3.8.2",
+"toml==0.10.2",
+]
 
-requires-python = ">=3.8"
+requires-python = ">=3.9,<3.13"
 
 dynamic = ["version"]
 
@@ -44,7 +44,7 @@ dynamic = ["version"]
 dev = ["black", "bumpver", "isort", "pip-tools", "pytest"]
 
 [tool.bumpver] #bump the version by entering `bumpver update` in the terminal
-current_version = "v2023.09.1004"
+current_version = "v2024.08.1008"
 version_pattern = "vYYYY.0M.BUILD[-TAG]"
 commit_message  = "Bump version {old_version} -> {new_version}"
 commit          = true

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -26,17 +26,17 @@ keywords = ["basic",
             "repository"] #change these to your project keywords
 
 dependencies = [
-"numpy==1.26.2",
-"pyside6==6.6.*",
-"pyqtgraph==0.13.3",
-"scipy==1.11.4",
-"rich==13.7.0",
-"pandas==2.1.4",
-"matplotlib==3.8.2",
-"toml==0.10.2",
-]
+"numpy",
+"pyqt6",
+"pyqtgraph",
+"scipy",
+"rich",
+"pandas",
+"matplotlib",
+"toml",
+] #add additional dependencies here - try to pin versions as minimally as possible
 
-requires-python = ">=3.9,<3.13"
+requires-python = ">=3.8"
 
 dynamic = ["version"]
 
@@ -44,7 +44,7 @@ dynamic = ["version"]
 dev = ["black", "bumpver", "isort", "pip-tools", "pytest"]
 
 [tool.bumpver] #bump the version by entering `bumpver update` in the terminal
-current_version = "v2024.08.1008"
+current_version = "v2023.09.1004"
 version_pattern = "vYYYY.0M.BUILD[-TAG]"
 commit_message  = "Bump version {old_version} -> {new_version}"
 commit          = true
@@ -57,4 +57,4 @@ push            = true
 
 
 [project.scripts]
-skellyforge = "skellyforge.__main__:main"
+skellyforge = "skellyforge.__main__:run"

--- a/skellyforge/__init__.py
+++ b/skellyforge/__init__.py
@@ -1,7 +1,7 @@
 """Top-level package for basic_template_repo."""
 
 __package_name__ = "skellyforge"
-__version__ = "v2024.08.1008"
+__version__ = "v2023.09.1004"
 
 __author__ = """Aaron Cherian"""
 __email__ = "info@freemocap.org"
@@ -11,12 +11,12 @@ __repo_url__ = (
 )
 __repo_issues_url__ = f"{__repo_url__}issues"
 
-import skellyforge.freemocap_utils as freemocap_utils
-from skellyforge.freemocap_utils.config import default_settings
-from skellyforge.freemocap_utils.constants import TASK_FILTERING, PARAM_CUTOFF_FREQUENCY, PARAM_SAMPLING_RATE, \
-    PARAM_ORDER, PARAM_ROTATE_DATA, TASK_SKELETON_ROTATION, TASK_INTERPOLATION, TASK_FINDING_GOOD_FRAME
+# import skellyforge.freemocap_utils as freemocap_utils
+# from skellyforge.freemocap_utils.config import default_settings
+# from skellyforge.freemocap_utils.constants import TASK_FILTERING, PARAM_CUTOFF_FREQUENCY, PARAM_SAMPLING_RATE, \
+#     PARAM_ORDER, PARAM_ROTATE_DATA, TASK_SKELETON_ROTATION, TASK_INTERPOLATION, TASK_FINDING_GOOD_FRAME
 
-from skellyforge.freemocap_utils.postprocessing_widgets.task_worker_thread import TaskWorkerThread
+# from skellyforge.freemocap_utils.postprocessing_widgets.task_worker_thread import TaskWorkerThread
 
 
 print(f"Thank you for using {__package_name__}!")

--- a/skellyforge/__init__.py
+++ b/skellyforge/__init__.py
@@ -1,7 +1,7 @@
 """Top-level package for basic_template_repo."""
 
 __package_name__ = "skellyforge"
-__version__ = "v2023.09.1004"
+__version__ = "v2024.08.1008"
 
 __author__ = """Aaron Cherian"""
 __email__ = "info@freemocap.org"

--- a/skellyforge/__main__.py
+++ b/skellyforge/__main__.py
@@ -1,12 +1,22 @@
 # __main__.py
 import sys
 from pathlib import Path
+import argparse
 
 base_package_path = Path(__file__).parent.parent
 print(f"adding base_package_path: {base_package_path} : to sys.path")
 sys.path.insert(0, str(base_package_path))  # add parent directory to sys.path
 
+def parse_args():
+    parser = argparse.ArgumentParser(description="SkellyForge")
+    return parser.parse_args()
 
-if __name__ == "__main__":
+def run():
+    parse_args()
+
     from postprocess_GUI import main
     main()
+
+if __name__ == "__main__":
+    run()
+


### PR DESCRIPTION
Same vibe as: https://github.com/freemocap/skelly_viewer/pull/19

Starter attempt at adding a help argument to skellyforge.

To test:

Create a fresh install of skellyforge for this PR
Try skellyforge --help
Try 'python -m skellyforge--help`
for 2 and 3 you should get a print statement that reads:

```
(skellyforge_dev) C:\Users\aaron\Documents\GitHub\skellyforge>skellyforge --help
Thank you for using skellyforge!
This is printing from: C:\Users\aaron\Documents\GitHub\skellyforge\skellyforge\__init__.py
Source code for this package is available at: https://github.com/freemocap/skellyforge/
adding base_package_path: C:\Users\aaron\Documents\GitHub\skellyforge : to sys.path
usage: skellyforge [-h]

SkellyForge

options:
  -h, --help  show this help message and exit
  ```
  
 NOTE 1: I changed the entry point in the pyproject.toml in order to get `skellyforge --help` to work in addition to `python -m skellyforge --help`

NOTE 2: A lot of the imports in `skellyforge` appear to be broken (so you can't run `skellyforge` or `python -m skellyforge`. Could look into fixing that as part of this PR or a different one. Part of this was all the import statements in `init.py`, which is why I commented those out. Do we even need those? 


 
 