### PR TITLE
Make pypi action manually runnable

### DIFF
--- a/.github/workflows/publish_to_pypi_when_new_tag_is_pushed_to_main.yml
+++ b/.github/workflows/publish_to_pypi_when_new_tag_is_pushed_to_main.yml
@@ -11,6 +11,7 @@ name: Upload Python Package
 on:
   push:
     tags: [ v* ]
+  workflow_dispatch:
 
 permissions:
   contents: read


### PR DESCRIPTION
The bumpver action isn't correctly triggering the pypi output. This adds a manual option for running the pypi action. We'll need to fix the bumpver action to correctly tag branches, but for now this will be helpful